### PR TITLE
Add optional info arg to strategy success callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export class GoogleOneTapStrategy extends Strategy {
         return this.fail(info, 401);
       }
 
-      this.success(user);
+      this.success(user, info);
     };
 
     this.verifyToken(req)

--- a/test/types/global.d.ts
+++ b/test/types/global.d.ts
@@ -4,7 +4,9 @@ import { Strategy } from "passport-strategy";
 
 interface ChaiPassportStrategy {
   use(strategy: Strategy): ChaiPassportStrategy;
-  success(callback: (profile: Profile) => void): ChaiPassportStrategy;
+  success(
+    callback: (profile: Profile, info?: object) => void
+  ): ChaiPassportStrategy;
   error(callback: (e: Error) => void): ChaiPassportStrategy;
   fail(
     callback: (challenge: string, status: number) => void


### PR DESCRIPTION
Passport.js [expects](https://github.com/jaredhanson/passport/blob/cfdbd4a762b51e339ebfea931d65bccbbde53282/lib/middleware/authenticate.js#L222) the strategy to call success() with a user and optionally an info argument. Missing info argument may introduce discrepancies between other passport strategies and this middleware.

#### Are you implementing a new feature?

No

#### Is this a security patch?

No

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Genially/passport-google-one-tap/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [x] I have added documentation/examples pertaining to this feature or patch.
- [x] The automated test suite (`$ npm run test`) executes successfully.
- [x] The automated code linting (`$ npm run lint`) executes successfully.
